### PR TITLE
Removed the max_current_monitor calls from the vesc.py and vesc_can_driver.py

### DIFF
--- a/karelics_vesc_can_driver/max_current_monitor.py
+++ b/karelics_vesc_can_driver/max_current_monitor.py
@@ -13,7 +13,11 @@ class MonitorMaxCurrent:
     during the time-window of max_draw_time*2 we check how many times have have
     crossed cont_current_lim. If more than half of the times, the motor is set on cool-down.
     This is required to monitor max discharge correctly also during fast spikes.
-    TODO: Currently only set_erpm and set_rpm functions use this in vesc.py.
+    TODO: For now the MonitorMaxCurrent is not used anymore as we are letting the VESC take care
+     of the overcurrents
+    TODO: If at any point in the future we will again want to use the max current monitor we need to
+     remember to scale the continous current limit with the current duty cycle that each motor is driven
+     with, as DUTY_CYCLE*MOTOR_CURRENT=BATTERY_CURRENT and that is what needs to be limited.
     """
 
     def __init__(self, node: Node, cont_current_lim, max_draw_time=2.0):

--- a/karelics_vesc_can_driver/vesc.py
+++ b/karelics_vesc_can_driver/vesc.py
@@ -10,8 +10,7 @@ from karelics_vesc_can_driver.vesc_messages import *
 
 class Vesc:
 
-    def __init__(self, node: Node, vesc_id, send_function, lock_function, release_function, motor_poles, gear_ratio,
-                 current_monitor):
+    def __init__(self, node: Node, vesc_id, send_function, lock_function, release_function, motor_poles, gear_ratio):
 
         self.node = node
 
@@ -21,7 +20,6 @@ class Vesc:
 
         self.motor_poles = int(motor_poles)
         self.gear_ratio = float(gear_ratio)
-        self.current_monitor = current_monitor
 
         # Status message
         self.erpm = 0
@@ -227,8 +225,6 @@ class Vesc:
             self.node.get_logger().error(str(e))
 
     def set_erpm_cb(self, msg: Float32):
-        if not self.current_monitor.is_safe():
-            msg.data = 0.0
         rpm_msg = VescSetRPM(rpm=msg.data)
         try:
             can_frame = rpm_msg.get_can_msg(self.vesc_id)
@@ -237,8 +233,6 @@ class Vesc:
             self.node.get_logger().error(str(e))
 
     def set_rpm_cb(self, msg: Float32):
-        if not self.current_monitor.is_safe():
-            msg.data = 0.0
         rpm_msg = VescSetRPM(rpm=float(msg.data * (self.motor_poles / 2) * self.gear_ratio))
         try:
             can_frame = rpm_msg.get_can_msg(self.vesc_id)

--- a/karelics_vesc_can_driver/vesc_can_driver.py
+++ b/karelics_vesc_can_driver/vesc_can_driver.py
@@ -10,7 +10,6 @@ from can_msgs.msg import Frame
 
 from karelics_vesc_can_driver.vesc_messages import *
 from karelics_vesc_can_driver.vesc import *
-from karelics_vesc_can_driver.max_current_monitor import MonitorMaxCurrent
 
 
 class CanMessageHandler:
@@ -85,9 +84,6 @@ class VescCanDriver(Node):
         self.declare_parameter('gear_ratio')
         self.gear_ratio = float(self.get_parameter('gear_ratio').value)
 
-        self.declare_parameter('continuous_current_limit')
-        self.cont_current_lim = int(self.get_parameter('continuous_current_limit').value)
-
         self.get_logger().info('Starting vesc can driver')
 
         # Subscribe to can topics
@@ -133,9 +129,6 @@ class VescCanDriver(Node):
         self.can_msg_handler.register_message(self.vesc_set_hb_msg)
         self.can_msg_handler.register_message(self.vesc_get_imu_data_msg)
 
-        # Set Current monitor to ensure battery health
-        self.current_monitor = MonitorMaxCurrent(node=self, cont_current_lim=self.cont_current_lim)
-
     def aquire_vesc_tool_id_lock(self, vesc_id):
         if self._active_vesc_id and self._active_vesc_id != vesc_id:
             return False
@@ -167,8 +160,7 @@ class VescCanDriver(Node):
                                              lock_function=self.aquire_vesc_tool_id_lock,
                                              release_function=self.release_vesc_tool_id_lock,
                                              motor_poles=self.motor_poles,
-                                             gear_ratio=self.gear_ratio,
-                                             current_monitor=self.current_monitor))
+                                             gear_ratio=self.gear_ratio))
         else:
             if self._active_vesc_id:
                 vesc_id = self._active_vesc_id
@@ -190,15 +182,14 @@ class VescCanDriver(Node):
         # Publish the current status of the current vesc in to ros world
         current_vesc.tick()
 
-        self.current_monitor.tick(self.known_vescs)
-
 
 if __name__ == '__main__':
     rclpy.init(args=sys.argv)
 
     karelics_vesc_can_driver_node = VescCanDriver()
 
-    rclpy.spin(karelics_vesc_can_driver_node)
-
-    karelics_vesc_can_driver_node.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(karelics_vesc_can_driver_node)
+    except KeyboardInterrupt:
+        karelics_vesc_can_driver_node.destroy_node()
+        rclpy.shutdown()

--- a/launch/karelics_vesc_can_driver.launch.py
+++ b/launch/karelics_vesc_can_driver.launch.py
@@ -20,7 +20,6 @@ def launch_setup(context, *args, **kwargs):
 
     motor_poles = LaunchConfiguration('motor_poles').perform(context)
     gear_ratio = LaunchConfiguration('gear_ratio').perform(context)
-    continuous_current_limit = LaunchConfiguration('continuous_current_limit').perform(context)
 
     emulate_tty_declare = DeclareLaunchArgument(
         'emulate_tty',
@@ -53,8 +52,7 @@ def launch_setup(context, *args, **kwargs):
         output='screen',
         emulate_tty=emulate_tty,
         parameters=[{'motor_poles': motor_poles,
-                     'gear_ratio': gear_ratio,
-                     'continuous_current_limit': continuous_current_limit}],
+                     'gear_ratio': gear_ratio}],
     )
 
     battery_status = Node(
@@ -81,6 +79,5 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('motor_poles'),
         DeclareLaunchArgument('gear_ratio'),
-        DeclareLaunchArgument('continuous_current_limit'),
         OpaqueFunction(function=launch_setup),
     ])


### PR DESCRIPTION
Jeffrey Friesen, Frand and Ben Vedder advised us to not use any extra layer of current monitoring besides the vescs after we went through the proper configs with them. As a result I removed the usages of the MaxCurrentMonitor but I have kept the code of the functionality still there if we might still need it at some point in the future. Also added the specification that we need to account for the current duty cycle of all the motors when limiting the current in the future, as atm we were aactually limiting the total motor current and not the total battery current.